### PR TITLE
docs: Add comprehensive README for project management processes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,58 @@
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme Project Management Processes repository. This folder contains comprehensive documentation on how OctoAcme runs projects, manages teams, and delivers value consistently.
+
+## Project Management Overview
+
+OctoAcme operates on a customer-first, iterative delivery model with clear ownership and data-driven decision-making. The organization applies a structured five-phase lifecycle to all cross-functional projects: **Initiation** (problem statement and stakeholder alignment), **Planning** (scope and backlog prioritization), **Execution** (build, test, review), **Release** (deploy and verify), and **Close & Retrospective** (capture learnings). This lifecycle ensures that every project starts with validated business need and measurable success criteria before resources are committed, reducing waste and misalignment.
+
+OctoAcme defines three core delivery roles: **Project Managers** coordinate schedules, risks, and communications to keep projects on track; **Product Managers** own the vision, prioritize the backlog, and measure outcomes; and **Developers** implement features with quality and testability in mind, supported by QA/Testing roles. Communication happens through a consistent cadence of daily standups (15 minutes, focused on blockers), weekly PM-PdM syncs, twice-weekly delivery team standups, and monthly stakeholder updates. This cadence prevents surprises and ensures rapid escalation of risks—with three escalation levels (team triage → PM → Product Lead → Sponsor) for addressing blockers at the appropriate level.
+
+During execution, teams use a project board (e.g., GitHub Projects) with standardized columns (Backlog, Ready, In Progress, In Review, QA, Done) and follow a disciplined pull request workflow with small PRs (≤400 lines), automated CI testing and linting, and mandatory peer review before merge. Quality is enforced through unit tests, integration tests, and end-to-end smoke tests for critical flows, along with security scanning in CI. Teams maintain a risk register (tracking ID, description, impact, likelihood, owner, and mitigation plan) and track velocity and burndown metrics to inform decision-making and identify early warnings.
+
+OctoAcme standardizes releases into three types (Patch, Minor, Major) with a pre-release checklist that covers acceptance criteria, CI/security scans, release notes, and smoke tests. Each release includes a deployment checklist and a documented rollback plan for rapid incident response. After each sprint, release, or milestone, teams conduct retrospectives (45–75 minutes) to capture what went well, what could improve, and generate 2–3 prioritized action items for the backlog. This emphasis on blameless retrospectives and continuous improvement reinforces psychological safety and ensures the team learns from each delivery cycle, feeding validated improvements back into living documentation for onboarding and consistency.
+
+## Process Document Links
+
+### Core Framework
+- [Project Management Overview](octoacme-project-management-overview.md) — High-level principles, core roles, key artifacts, and communication cadence
+
+### Project Phases
+- [Project Initiation Guide](octoacme-project-initiation.md) — Define problem, goals, stakeholders, and approval
+- [Project Planning](octoacme-project-planning.md) — Create actionable backlogs, estimate, plan timelines, identify dependencies
+- [Execution & Tracking](octoacme-execution-and-tracking.md) — Sync daily, manage PRs, track metrics, escalate blockers
+- [Release & Deployment Guide](octoacme-release-and-deployment.md) — Standardize pre-release checks, deployment, rollbacks, and documentation
+
+### Continuous Improvement & Support
+- [Risk Management & Communication](octoacme-risks-and-communication.md) — Document and manage risks, escalate, and communicate with stakeholders
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md) — Capture learnings, create actionable improvements, review outcomes
+- [Roles & Personas](octoacme-roles-and-personas.md) — Define core roles and typical responsibilities
+
+## Documentation Structure
+
+Each process document follows this standard structure:
+- **Purpose** — What the document covers and when to use it
+- **Key Activities/Workflows** — How to execute the process
+- **Templates & Checklists** — Reusable artifacts and decision gates
+- **Quick Links** — References to related documents
+
+## How to Use These Docs
+
+1. **Getting Started?** Begin with [Project Management Overview](octoacme-project-management-overview.md) for a high-level introduction.
+2. **Starting a New Project?** Follow the sequence: [Initiation](octoacme-project-initiation.md) → [Planning](octoacme-project-planning.md) → [Execution & Tracking](octoacme-execution-and-tracking.md).
+3. **Ready to Release?** Check [Release & Deployment Guide](octoacme-release-and-deployment.md) and [Risk Management & Communication](octoacme-risks-and-communication.md).
+4. **Improving the Process?** Use [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md) to capture learnings and update these docs.
+
+## Adding New Documentation
+
+As OctoAcme's processes evolve, new documentation will be added to this folder. To propose updates or new process docs:
+1. Open an issue using the [Add Content to Project Management Process Docs](../.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml) template
+2. Include a summary of the new content, rationale, and suggested text
+3. Work with stakeholders to validate alignment before merging
+
+---
+
+**Last Updated:** April 2026  
+**Maintained By:** OctoAcme Project Management Community
+
+_This README will be updated as new process docs are added._


### PR DESCRIPTION
Resolves #2

## Summary
Creates a central README for the OctoAcme Project Management Docs folder that improves discoverability and provides a guided entry point for team members.

## Changes
- Added `docs/README.md` with:
  - 4-paragraph overview of OctoAcme's PM framework
  - Clearly labeled links to all 7 process documents organized by category
  - Documentation structure guide for future additions
  - "How to Use These Docs" quick reference section

## Alignment
- Content synthesizes all existing process documents in the folder
- Follows the same principles and terminology established in existing docs
- Supports the Copilot Space's purpose of centralizing scattered project management knowledge
- Improves onboarding and reduces single-person dependency risk